### PR TITLE
feat: support async predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ try {
 
 ## Supported arguments
 
-```javascript
+```typescript
 /**
  * Waits for predicate to be truthy and resolves a Promise
  *
@@ -97,7 +97,7 @@ function waitUntil<T>(
 
 ## TypeScript
 
-The library exports type definitions for TypeScript. As far as the library ships the code with `commonJS` module support only, you have to use `import waitUtil = require()` syntax to use it:
+The library exports type definitions for TypeScript. As far as the library ships the code with `commonJS` module support only, you have to use `import waitUntil = require()` syntax to use it:
 
 ```typescript
 import waitUntil = require('async-wait-until');

--- a/README.md
+++ b/README.md
@@ -87,20 +87,20 @@ try {
  * @param  interval  Number  Wait interval, optional, 50ms by default
  * @return  Promise  Promise to return a callback result
  */
-function waitUntil(
-    predicate: Function,
+function waitUntil<T>(
+    predicate: () => T | Promise<T>,
     timeout: number = 5000,
-    interval: number = 50
-): Promise;
+    interval: number = 50,
+): Promise<Exclude<T, Falsy>>;
 ```
 
 
 ## TypeScript
 
-The library exports type definitions for TypeScript. As far as the library ships the code with `commonJS` module support only, you have to use `import * as` syntax to use it:
+The library exports type definitions for TypeScript. As far as the library ships the code with `commonJS` module support only, you have to use `import waitUtil = require()` syntax to use it:
 
 ```typescript
-import * as waitUntil from 'async-wait-until';
+import waitUntil = require('async-wait-until');
 
 const timeOfStart = Date.now();
 
@@ -137,23 +137,25 @@ $ npm run test:coverage
 
  PASS  test/waitUntil.js
   waitUntil
-    ✓ Should apply callback and resolve result (219ms)
-    ✓ Should apply callback and resolve non-boolean result (209ms)
-    ✓ Should reject with timeout error if timed out (108ms)
-    ✓ Should not do double reject on timeout (205ms)
-    ✓ Should not do double reject on timeout if error in predicate (213ms)
-    ✓ Should reject result if error in predicate (55ms)
+    ✓ Should apply callback and resolve result (216ms)
+    ✓ Should apply async callback and resolve result (208ms)
+    ✓ Should apply callback and resolve non-boolean result (207ms)
+    ✓ Should reject with timeout error if timed out (103ms)
+    ✓ Should not do double reject on timeout (206ms)
+    ✓ Should not do double reject on timeout if error in predicate (201ms)
+    ✓ Should reject result if error in predicate (51ms)
+    ✓ Should reject result if error in async predicate (103ms)
 
---------------|----------|----------|----------|----------|----------------|
-File          |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------|----------|----------|----------|----------|----------------|
-All files     |      100 |      100 |      100 |      100 |                |
- waitUntil.js |      100 |      100 |      100 |      100 |                |
---------------|----------|----------|----------|----------|----------------|
+--------------|----------|----------|----------|----------|-------------------|
+File          |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+--------------|----------|----------|----------|----------|-------------------|
+All files     |      100 |      100 |      100 |      100 |                   |
+ waitUntil.js |      100 |      100 |      100 |      100 |                   |
+--------------|----------|----------|----------|----------|-------------------|
 Test Suites: 1 passed, 1 total
-Tests:       6 passed, 6 total
+Tests:       8 passed, 8 total
 Snapshots:   0 total
-Time:        1.984s
+Time:        2.217s
 Ran all test suites.
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,14 +137,15 @@ $ npm run test:coverage
 
  PASS  test/waitUntil.js
   waitUntil
-    ✓ Should apply callback and resolve result (216ms)
-    ✓ Should apply async callback and resolve result (208ms)
-    ✓ Should apply callback and resolve non-boolean result (207ms)
-    ✓ Should reject with timeout error if timed out (103ms)
-    ✓ Should not do double reject on timeout (206ms)
-    ✓ Should not do double reject on timeout if error in predicate (201ms)
-    ✓ Should reject result if error in predicate (51ms)
-    ✓ Should reject result if error in async predicate (103ms)
+    ✓ Should apply callback and resolve result (213ms)
+    ✓ Should apply async callback and resolve result (213ms)
+    ✓ Should apply callback and resolve non-boolean result (217ms)
+    ✓ Should reject with timeout error if timed out (105ms)
+    ✓ Should not do double reject on timeout (201ms)
+    ✓ Should not do double reject on timeout if error in predicate (206ms)
+    ✓ Should reject result if error in predicate (55ms)
+    ✓ Should reject result if error in async predicate (101ms)
+    ✓ Should not async resolve on timeout (177ms)
 
 --------------|----------|----------|----------|----------|-------------------|
 File          |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
@@ -153,9 +154,9 @@ All files     |      100 |      100 |      100 |      100 |                   |
  waitUntil.js |      100 |      100 |      100 |      100 |                   |
 --------------|----------|----------|----------|----------|-------------------|
 Test Suites: 1 passed, 1 total
-Tests:       8 passed, 8 total
+Tests:       9 passed, 9 total
 Snapshots:   0 total
-Time:        2.217s
+Time:        2.162s
 Ran all test suites.
 ```
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,11 +3,12 @@
 // Definitions by: devlato <https://github.com/devlato>
 //                 Mike Coakley <mcoakley@acmeframework.com>
 
-declare module 'async-wait-until' {
-  type WaitPredicate<T> = () => T | null | undefined | false | '' | 0;
-  type WaitUntil = <T>(fn: WaitPredicate<T>, timeout?: number, interval?: number) => Promise<T>;
+type Promisable<T> = T | Promise<T>;
+type Falsy = false | 0 | '' | null | undefined
 
-  const waitUntil: WaitUntil;
+declare module 'async-wait-until' {
+  type WaitPredicate<T> = () => Promisable<T>;
+  function waitUntil<T extends any>(fn: WaitPredicate<T>, timeout?: number, interval?: number): Promise<Exclude<T, Falsy>>;
 
   export = waitUntil;
 }

--- a/src/waitUntil.js
+++ b/src/waitUntil.js
@@ -30,21 +30,22 @@ module.exports = function waitUntil(
     };
 
     doStep = function doTimerStep() {
-      var result;
-
-      try {
-        result = predicate();
-
-        if (result) {
+      Promise.resolve(null)
+        .then(function wrapPredicate() {
+          return predicate();
+        })
+        .then(function onResolved(result) {
+          if (result) {
+            clearTimers();
+            resolve(result);
+          } else {
+            timer = setTimeout(doStep, timerInterval);
+          }
+        })
+        .catch(function onRejected(e) {
           clearTimers();
-          resolve(result);
-        } else {
-          timer = setTimeout(doStep, timerInterval);
-        }
-      } catch (e) {
-        clearTimers();
-        reject(e);
-      }
+          reject(e);
+        });
     };
 
     timer = setTimeout(doStep, timerInterval);

--- a/test/waitUntil.js
+++ b/test/waitUntil.js
@@ -1,5 +1,13 @@
 var waitUntil = require('../src/waitUntil');
 
+function sleep(ms) {
+  return new Promise(function (resolve) {
+    setTimeout(function () {
+      resolve();
+    }, ms)
+  })
+}
+
 
 describe('waitUntil', function() {
   it('Should apply callback and resolve result', function() {
@@ -127,6 +135,26 @@ describe('waitUntil', function() {
         expect(result.toString())
           .toEqual('Error: Crap!');
       });
+  });
+
+  it('Should not async resolve on timeout', function () {
+    return waitUntil(function fnResolveOkAfter100ms() {
+      return sleep(100)
+        .then(function () {
+          return 'Ok'
+        });
+    }, 50, 10)
+      .catch(function fnRelayErrorAfter120ms(err) {
+        return sleep(120)
+          .then(function () {
+            throw err;
+          });
+      })
+      .catch(function (err) {
+        expect(err.toString())
+          .toEqual('Error: Timed out after waiting for 50ms');
+      });
+
   });
 
 });

--- a/test/waitUntil.js
+++ b/test/waitUntil.js
@@ -8,10 +8,26 @@ describe('waitUntil', function() {
     return waitUntil(function() {
       return (Date.now() - initialTime > 200);
     })
-    .then(function (result) {
-      expect(result)
+      .then(function (result) {
+        expect(result)
           .toEqual(true);
-    });
+      });
+  });
+
+  it('Should apply async callback and resolve result', function() {
+    var initialTime = Date.now();
+
+    return waitUntil(function() {
+      return new Promise(function (resolve) {
+        setTimeout(function () {
+          resolve(Date.now() - initialTime > 200)
+        }, 50)
+      })
+    })
+      .then(function (result) {
+        expect(result)
+          .toEqual(true);
+      });
   });
 
 
@@ -36,13 +52,13 @@ describe('waitUntil', function() {
     return waitUntil(function() {
       return (Date.now() - initialTime > 500);
     }, 100)
-    .catch(function (result) {
-      expect(result)
+      .catch(function (result) {
+        expect(result)
           .toBeInstanceOf(Error);
 
-      expect(result.toString())
+        expect(result.toString())
           .toEqual('Error: Timed out after waiting for 100ms');
-    });
+      });
   });
 
 
@@ -86,12 +102,31 @@ describe('waitUntil', function() {
     return waitUntil(function() {
       throw new Error('Crap!');
     })
-    .catch(function (result) {
-      expect(result)
+      .catch(function (result) {
+        expect(result)
           .toBeInstanceOf(Error);
 
-      expect(result.toString())
+        expect(result.toString())
           .toEqual('Error: Crap!');
-    });
+      });
   });
+
+
+  it('Should reject result if error in async predicate', function() {
+    return waitUntil(function() {
+      return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+          reject(new Error('Crap!'));
+        }, 50)
+      })
+    })
+      .catch(function (result) {
+        expect(result)
+          .toBeInstanceOf(Error);
+
+        expect(result.toString())
+          .toEqual('Error: Crap!');
+      });
+  });
+
 });


### PR DESCRIPTION
**Changes**

- add async predicate support
- corrected README (CJS style export `export = xxx` should be imported with `import xxx = require('xxx')` in TypeScript)